### PR TITLE
TiLDA_EPD: Clean up all non DUE SPI code, should make it clean for ..

### DIFF
--- a/hardware/emfcamp/sam/libraries/TiLDA_EPD/TiLDA_EPD.h
+++ b/hardware/emfcamp/sam/libraries/TiLDA_EPD/TiLDA_EPD.h
@@ -14,7 +14,7 @@
 
 /*
  Orignal from https://github.com/repaper/gratis/
- Modified my EMF Camp for the TiLDA Mk2
+ Modified by EMF Camp for the TiLDA Mk2
 */
 
 #if !defined(EPD_H)


### PR DESCRIPTION
...porting to RTOS later

When I first ported the EPD driver I added a load of if def's to keep non due compatibility

This cleans up all that code thats not need as long as we keep to the Due extended SPI 
http://arduino.cc/en/Reference/DueExtendedSPI

At some point we will be porting most of the functionality of this into an RTOS compatible version which will use our RTOS_SPI library
