### PR TITLE
Fix a minor typo in 'no weather yet' message

### DIFF
--- a/EMF2014/WeatherApp.cpp
+++ b/EMF2014/WeatherApp.cpp
@@ -120,7 +120,7 @@ bool WeatherApp::getWeatherString(String& forecastStr, const WeatherForecast& aW
         forecastStr += String(wfp.screenRelativeHumidity) + "% humidity\n";
         forecastStr += String(wfp.precipitationProbability) + "% chance of rain\n";
     } else {
-        forecastStr = "Sorry, no forecast recieved yet. Please try later (or wiggle the joystick to check for update).";
+        forecastStr = "Sorry, no forecast received yet. Please try later (or wiggle the joystick to check for update).";
     }
     return aWeatherForecast.mValid;
 }


### PR DESCRIPTION
i before e, except after c. And all the other exceptions.
