### PR TITLE
Fix a couple of uninitialized variables spotted by cppcheck.

### DIFF
--- a/EMF2014/DataStore.cpp
+++ b/EMF2014/DataStore.cpp
@@ -49,7 +49,7 @@ DataStore::DataStore(MessageCheckTask& aMessageCheckTask)
 	for (int day = 0 ; day < SCHEDULE_NUM_DAYS ; ++day)
 		mSchedule[day] = new Schedule*[LOCATION_COUNT];
 
-	for (int day ; day < SCHEDULE_NUM_DAYS ; ++day)
+	for (int day = 0 ; day < SCHEDULE_NUM_DAYS ; ++day)
 		for (int location = 0 ; location < LOCATION_COUNT ; ++location)
 			mSchedule[day][location] = new Schedule(NULL, 0);
 
@@ -64,7 +64,7 @@ DataStore::~DataStore() {
 
     delete mWeatherForecast;
 
-    for (int day ; day < SCHEDULE_NUM_DAYS ; ++day)
+    for (int day = 0 ; day < SCHEDULE_NUM_DAYS ; ++day)
 		for (int location = 0 ; location < LOCATION_COUNT ; ++location)
 			delete mSchedule[day][location];
     delete[] mSchedule;

--- a/EMF2014/ScheduleApp.cpp
+++ b/EMF2014/ScheduleApp.cpp
@@ -166,7 +166,7 @@ const char* ScheduleApp::locationsCallback(uint8_t location, uint8_t msg) {
     mSchedule = Tilda::getDataStore().getSchedule(LAST_SELECTED_DAY, location);
 
     Event* events = mSchedule->getEvents();
-    for (int i ; i < mSchedule->getEventCount() ; ++i) {
+    for (int i = 0 ; i < mSchedule->getEventCount() ; ++i) {
         // Create a string for the list
         // <start time> (title)
         RTC_date_time start = RTC_clock::from_unixtime(events[i].startTimestamp + TIMEZONE_OFFSET);


### PR DESCRIPTION
This fixes a couple of uninitialized variables reported by cppcheck

[DataStore.cpp:52]: (error) Uninitialized variable: day
[DataStore.cpp:67]: (error) Uninitialized variable: day
[ScheduleApp.cpp:169]: (error) Uninitialized variable: i
