### PR TITLE
Fix occasional screen corruption by changing GLCD locking

### DIFF
--- a/hardware/emfcamp/sam/libraries/GLCD/gText.cpp
+++ b/hardware/emfcamp/sam/libraries/GLCD/gText.cpp
@@ -286,6 +286,9 @@ void gText::ScrollUp(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2,
         return;
     }
 
+    if (this->Acquire() != pdTRUE)
+        return;
+
     for (col = x1; col <= x2; col++) {
         dy = y1;
         glcd_Device::GotoXY(col, dy & ~7);
@@ -366,6 +369,7 @@ void gText::ScrollUp(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2,
             this->WriteData(dbyte);
         }
     }
+    this->Release();
 }
 
 #ifndef GLCD_NO_SCROLLDOWN
@@ -389,6 +393,9 @@ void gText::ScrollDown(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2,
         glcd_Device::SetPixels(x1, y1, x2, y2, color);
         return;
     }
+
+    if (this->Acquire() != pdTRUE)
+        return;
 
     /*
     * Process region from left to right
@@ -467,6 +474,7 @@ void gText::ScrollDown(uint8_t x1, uint8_t y1, uint8_t x2, uint8_t y2,
             this->WriteData(dbyte);
         }
     }
+    this->Release();
 }
 #endif // GLCD_NO_SCROLLDOWN
 
@@ -753,6 +761,9 @@ int gText::PutChar(uint8_t c) {
 
 #ifdef GLCD_OLD_FONTDRAW
     /*================== OLD FONT DRAWING ============================*/
+    if (this->Acquire() != pdTRUE)
+        return 0;
+
     glcd_Device::GotoXY(this->x, this->y);
 
     /*
@@ -805,6 +816,8 @@ int gText::PutChar(uint8_t c) {
     }
     this->x = this->x + width + 1;
 
+    this->Release();
+
 /*================== END of OLD FONT DRAWING ============================*/
 #else
 
@@ -838,6 +851,9 @@ int gText::PutChar(uint8_t c) {
     uint8_t dp;
     uint8_t dbyte;
     uint8_t fdata;
+
+    if (this->Acquire() != pdTRUE)
+        return 0;
 
     for (p = 0; p < pixels;) {
         dy = this->y + p;
@@ -1036,6 +1052,7 @@ int gText::PutChar(uint8_t c) {
 
     this->x = this->x + width + 1;
 
+    this->Release();
 /*================== END of NEW FONT DRAWING ============================*/
 
 #endif // NEW_FONTDRAW

--- a/hardware/emfcamp/sam/libraries/GLCD/glcd.cpp
+++ b/hardware/emfcamp/sam/libraries/GLCD/glcd.cpp
@@ -362,6 +362,9 @@ void glcd::InvertRect(uint8_t x, uint8_t y, uint8_t width, uint8_t height) {
     /*
      * First do the fractional pages at the top of the region
      */
+    if (this->Acquire() != pdTRUE)
+      return;
+
     this->GotoXY(x, y);
     for (i = 0; i <= width; i++) {
         data = this->ReadData();
@@ -398,6 +401,7 @@ void glcd::InvertRect(uint8_t x, uint8_t y, uint8_t width, uint8_t height) {
             this->WriteData(data);
         }
     }
+    this->Release();
 }
 /**
  * Set LCD Display mode
@@ -438,6 +442,10 @@ void glcd::DrawBitmap(Image_t bitmap, uint8_t x, uint8_t y, uint8_t color) {
 
     width = ReadPgmData(bitmap++);
     height = ReadPgmData(bitmap++);
+
+    if (this->Acquire() != pdTRUE)
+      return;
+
 #define BITMAP_FIX
 #ifdef BITMAP_FIX // temporary ifdef just to show what changes if a new
                   // bit rendering routine is written.
@@ -485,6 +493,7 @@ void glcd::DrawBitmap(Image_t bitmap, uint8_t x, uint8_t y, uint8_t color) {
                 this->WriteData(~displayData);
         }
     }
+    this->Release();
 }
 
 #ifdef NOTYET

--- a/hardware/emfcamp/sam/libraries/GLCD/glcd_Device.cpp
+++ b/hardware/emfcamp/sam/libraries/GLCD/glcd_Device.cpp
@@ -60,6 +60,9 @@ void glcd_Device::SetDot(uint8_t x, uint8_t y, uint8_t color) {
     if ((x >= this->CurrentWidth()) || (y >= this->CurrentHeight()))
         return;
 
+    if (this->Acquire() != pdTRUE)
+        return;
+
     this->GotoXY(x, y - y % 8); // read data from display memory
 
     data = this->ReadData();
@@ -69,6 +72,7 @@ void glcd_Device::SetDot(uint8_t x, uint8_t y, uint8_t color) {
         data &= ~(0x01 << (y % 8)); // clear dot
     }
     this->WriteData(data); // write data back to display
+    this->Release();
 }
 
 /**
@@ -111,6 +115,9 @@ void glcd_Device::SetPixels(uint8_t x, uint8_t y, uint8_t x2, uint8_t y2,
     }
     mask <<= pageOffset;
 
+    if (this->Acquire() != pdTRUE)
+        return;
+
     this->GotoXY(x, y);
     for (i = 0; i < width; i++) {
         data = this->ReadData();
@@ -150,6 +157,7 @@ void glcd_Device::SetPixels(uint8_t x, uint8_t y, uint8_t x2, uint8_t y2,
             this->WriteData(data);
         }
     }
+    this->Release();
 }
 
 /*

--- a/hardware/emfcamp/sam/libraries/GLCD/glcd_Device.h
+++ b/hardware/emfcamp/sam/libraries/GLCD/glcd_Device.h
@@ -120,8 +120,6 @@ class glcd_Device : public Print {
   public:
     glcd_Device();
     void WaitForUpdate(void);
-    uint8_t ReadData(void);
-    void WriteData(uint8_t);
     void Init();
     void Display();
     uint8_t CurrentWidth();
@@ -133,7 +131,14 @@ class glcd_Device : public Print {
     void SetDot(uint8_t x, uint8_t y, uint8_t color);
     void SetPixels(uint8_t x, uint8_t y, uint8_t x1, uint8_t y1, uint8_t color);
 
+    uint8_t Acquire(void);
+    void Release(void);
+
+    // These must only be called after a successful Acquire()
+    // Screen will only be updated after Release()
     void GotoXY(uint8_t x, uint8_t y);
+    uint8_t ReadData(void);
+    void WriteData(uint8_t);
 };
 
 #endif


### PR DESCRIPTION
This moves mutex protection in GLCD up a layer which fixes the occasional
screen corruption seen in some of the apps.

The locking helps avoid the situation where multiple tasks could call
GotoXY() to update the internal position without taking a lock. This
position determines what data is accessed by ReadData() and WriteData().
An invalid position could cause memory access beyond the framebuffer.

Moving the locking up to the higher level drawing routines causes
the mutex to be held for longer but also means the display update
is more likely to be triggered after a complete drawing operation
instead of in the middle.
