### PR TITLE
Fix occasional hangs in Snake app.

### DIFF
--- a/EMF2014/SnakeApp.cpp
+++ b/EMF2014/SnakeApp.cpp
@@ -78,6 +78,7 @@ void SnakeApp::task() {
 
             while(!snake.game_over()) {
                 uint32_t nextFrame = Tilda::millisecondsSinceBoot() + FRAME_DURATION;
+                uint32_t timeout;
 
                 if (score != snake.length()) {
                     score = snake.length();
@@ -97,8 +98,8 @@ void SnakeApp::task() {
                 snake.render_start();
                 snake.render_tick();
 
-                while (nextFrame - Tilda::millisecondsSinceBoot() > 0) {
-                    Button button = mButtonSubscription->waitForPress(nextFrame - Tilda::millisecondsSinceBoot());
+                while ((timeout = nextFrame - Tilda::millisecondsSinceBoot()) > 0) {
+                    Button button = mButtonSubscription->waitForPress(timeout);
                     if (button == UP) {
                         snake.dir_up();
                     } else if (button == DOWN) {


### PR DESCRIPTION
The timeout passed to waitForPress() could become negative in
the time elapsed between the time it is checked and used. This
would cause the app to stop responding to input. The badge would
eventually return to the home screen after the app was killed.
