### PR TITLE
Split the three different uxBits checks in the PMIC task. 

### DIFF
--- a/EMF2014/PMICTask.cpp
+++ b/EMF2014/PMICTask.cpp
@@ -135,16 +135,17 @@ void PMICTask::task()
             // new sample rate notting todo but clear the bit and re enter the wait
             xEventGroupClearBits(eventGroup,
                                  PMIC_SAMPLE_RATE_BIT);
-            
-        } else if ((uxBits & PMIC_CHAREG_STATE_BIT) != 0 ) {
+        }
+
+        if ((uxBits & PMIC_CHAREG_STATE_BIT) != 0 ) {
             chargeState = digitalRead(MCP_STAT);
             xEventGroupClearBits(eventGroup,
                                  PMIC_CHAREG_STATE_BIT);
             debug::log("PMICTask: New charge state: " + String(chargeState));
             // TODO: notify others that want to know about state change
-            
-            
-        } else {
+        }
+
+        if ((uxBits & (PMIC_CHAREG_STATE_BIT | PMIC_SAMPLE_RATE_BIT)) == 0 ) {
             // wait timed out, time to sample the battery voltage
             batteryReading = analogRead(VBATT_MON);
             chargeState = digitalRead(MCP_STAT);


### PR DESCRIPTION
This pull is more for comment & review rather than a firm pull request. I'm not sure whether submitting a pull request is appropriate or not.

The only significant difference occurs if the SAMPLE_RATE and CHAREG_STATE event flags are both set
simultaneously. Previously only the SAMPLE_RATE bit would be handled and cleared
for this case, now both will be processed. I don't know whether this makes a
difference in practice but it appears cleaner.

Is CHAREG_STATE a typo?
