### PR TITLE
Update PMIC and IMU interrupt handlers to be like FreeRTOS examples

### DIFF
--- a/EMF2014/IMUTask.cpp
+++ b/EMF2014/IMUTask.cpp
@@ -77,14 +77,15 @@ static signed char gyro_orientation[9] = { 1, 0, 0,             // X axis mappin
 // Callbacks
 static void IMU_interrupt(void) {
     if (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
-        static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        BaseType_t xResult;
         
         // set the int state bit to wake the IMU Task
-        xEventGroupSetBitsFromISR(imuTask.eventGroup,
-                                  IMU_INT_BIT,
-                                  &xHigherPriorityTaskWoken);
+        xResult = xEventGroupSetBitsFromISR(imuTask.eventGroup,
+                                            IMU_INT_BIT,
+                                            &xHigherPriorityTaskWoken);
         
-        if (xHigherPriorityTaskWoken) {
+        if (xResult == pdPASS) {
             portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
         }
     }

--- a/EMF2014/PMICTask.cpp
+++ b/EMF2014/PMICTask.cpp
@@ -44,14 +44,15 @@
 static void PMICChargeStateInterrupt(void)
 {
     if (xTaskGetSchedulerState() == taskSCHEDULER_RUNNING) {
-        static BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        BaseType_t xResult;
         
         // set the Charge state bit to wake the PMIC Task
-        xEventGroupSetBitsFromISR(PMIC.eventGroup,
-                                  PMIC_CHAREG_STATE_BIT,
-                                  &xHigherPriorityTaskWoken);
+        xResult = xEventGroupSetBitsFromISR(PMIC.eventGroup,
+                                            PMIC_CHAREG_STATE_BIT,
+                                            &xHigherPriorityTaskWoken);
         
-        if (xHigherPriorityTaskWoken) {
+        if (xResult == pdPASS) {
             portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
         }
     }


### PR DESCRIPTION
This pull is more for comment & review rather than a firm pull request. I have no previous experience with FreeRTOS but the current code seems inconsistent with the examples of xEventGroupSetBitsFromISR() in event_groups.h and http://www.freertos.org/xEventGroupSetBitsFromISR.html

I have been wondering whether the PMIC is responsible for some lockups because the USB serial debug occasionally reports a flood of charge state changes. Perhaps there is noise on the MCP_STAT line or maybe the battery charger is oscillating between the charging and non-charging states as the dynamic CPU power usage effects the battery voltage.
