### PR TITLE
Fix snake app hangs due to integer wrap.

### DIFF
--- a/EMF2014/SnakeApp.cpp
+++ b/EMF2014/SnakeApp.cpp
@@ -78,7 +78,7 @@ void SnakeApp::task() {
 
             while(!snake.game_over()) {
                 uint32_t nextFrame = Tilda::millisecondsSinceBoot() + FRAME_DURATION;
-                uint32_t timeout;
+                int32_t timeout;
 
                 if (score != snake.length()) {
                     score = snake.length();


### PR DESCRIPTION
Previous fix missed that the timeout variable needs signed otherwise it wraps to a large positive integer.
